### PR TITLE
Fix feature-tree build issues for Boost 1.83

### DIFF
--- a/Code/GraphMol/Basement/FeatTrees/FeatTree.h
+++ b/Code/GraphMol/Basement/FeatTrees/FeatTree.h
@@ -13,7 +13,7 @@
 #define _RD_FEATTREE_H_
 
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/property_map.hpp>
+#include <boost/property_map/property_map.hpp>
 #include <boost/shared_ptr.hpp>
 #include <set>
 

--- a/Code/GraphMol/Basement/FeatTrees/FeatTreeSimilarity.cpp
+++ b/Code/GraphMol/Basement/FeatTrees/FeatTreeSimilarity.cpp
@@ -1,0 +1,237 @@
+//
+//  Copyright (C) 2024  RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "FeatTreeSimilarity.h"
+
+#include <GraphMol/Atom.h>
+#include <GraphMol/Bond.h>
+#include <GraphMol/MolOps.h>
+#include <GraphMol/RWMol.h>
+#include <GraphMol/RingInfo.h>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+
+namespace RDKit {
+namespace FeatTrees {
+namespace {
+
+bool isDonor(const Atom *atom) {
+  if (!atom) {
+    return false;
+  }
+  const unsigned int atomicNum = atom->getAtomicNum();
+  if ((atomicNum == 7 || atomicNum == 8 || atomicNum == 16) &&
+      atom->getTotalNumHs() > 0) {
+    return true;
+  }
+  return false;
+}
+
+bool isAcceptor(const Atom *atom) {
+  if (!atom) {
+    return false;
+  }
+  const unsigned int atomicNum = atom->getAtomicNum();
+  if (atomicNum == 7 || atomicNum == 8 || atomicNum == 9 || atomicNum == 16) {
+    if (atom->getFormalCharge() <= 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool containsAmideLike(const ROMol &mol,
+                       const std::set<unsigned int> &indices) {
+  for (const unsigned int idx : indices) {
+    const Atom *atom = mol.getAtomWithIdx(idx);
+    if (!atom || atom->getAtomicNum() != 6) {
+      continue;
+    }
+    for (const auto bond : mol.atomBonds(atom)) {
+      const Bond *b = bond;
+      const unsigned int otherIdx = b->getOtherAtomIdx(idx);
+      if (!indices.count(otherIdx)) {
+        continue;
+      }
+      const Atom *nbr = mol.getAtomWithIdx(otherIdx);
+      if (b->getBondType() == Bond::BondType::DOUBLE &&
+          nbr->getAtomicNum() == 8) {
+        for (const auto bond2 : mol.atomBonds(atom)) {
+          const Bond *b2 = bond2;
+          const unsigned int other = b2->getOtherAtomIdx(idx);
+          if (!indices.count(other)) {
+            continue;
+          }
+          const Atom *nbr2 = mol.getAtomWithIdx(other);
+          if (nbr2->getAtomicNum() == 7 &&
+              b2->getBondType() == Bond::BondType::SINGLE) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+FragmentProfile computeFragmentProfile(const ROMol &mol,
+                                       const std::set<unsigned int> &indices) {
+  FragmentProfile profile;
+  int carbonCount = 0;
+  for (const unsigned int idx : indices) {
+    const Atom *atom = mol.getAtomWithIdx(idx);
+    if (!atom) {
+      continue;
+    }
+    ++profile.volume;
+    if (atom->getAtomicNum() == 6) {
+      ++carbonCount;
+    }
+    if (mol.getRingInfo()->numAtomRings(idx) > 0) {
+      profile.ring = true;
+    }
+    if (atom->getIsAromatic()) {
+      profile.aromatic = true;
+    }
+    if (isDonor(atom)) {
+      ++profile.donors;
+    }
+    if (isAcceptor(atom)) {
+      ++profile.acceptors;
+    }
+  }
+  if (profile.volume > 0) {
+    profile.hydrophobicity = static_cast<double>(carbonCount) /
+                             static_cast<double>(profile.volume);
+  }
+  profile.amide = containsAmideLike(mol, indices);
+  return profile;
+}
+
+std::vector<FragmentProfile> buildFragmentProfiles(const ROMol &mol,
+                                                   const FeatTreeGraph &tree) {
+  std::vector<FragmentProfile> profiles;
+  profiles.reserve(boost::num_vertices(tree));
+  const auto nodeMap = boost::get(FeatTreeNode_t(), tree);
+  for (auto vp = boost::vertices(tree); vp.first != vp.second; ++vp.first) {
+    const auto v = *vp.first;
+    const UINT_SET &atomSet = nodeMap[v];
+    std::set<unsigned int> indices(atomSet.begin(), atomSet.end());
+    profiles.push_back(computeFragmentProfile(mol, indices));
+  }
+  return profiles;
+}
+
+std::vector<FragmentProfile> buildFragmentProfiles(const ROMol &mol) {
+  auto tree = molToBaseTree(mol);
+  if (!tree) {
+    return {};
+  }
+  return buildFragmentProfiles(mol, *tree);
+}
+
+double compareFragmentProfiles(const FragmentProfile &lhs,
+                               const FragmentProfile &rhs) {
+  double score = 0.0;
+  int count = 0;
+
+  if (lhs.volume > 0 || rhs.volume > 0) {
+    const double diff = std::abs(lhs.volume - rhs.volume);
+    const double maxv = static_cast<double>(std::max(lhs.volume, rhs.volume));
+    score += 1.0 - diff / maxv;
+  } else {
+    score += 1.0;
+  }
+  ++count;
+
+  score += (lhs.ring == rhs.ring) ? 1.0 : 0.0;
+  ++count;
+
+  if (lhs.donors > 0 || rhs.donors > 0) {
+    const double diff = std::abs(lhs.donors - rhs.donors);
+    const double maxv = static_cast<double>(std::max(lhs.donors, rhs.donors));
+    score += 1.0 - diff / maxv;
+  } else {
+    score += 1.0;
+  }
+  ++count;
+
+  if (lhs.acceptors > 0 || rhs.acceptors > 0) {
+    const double diff = std::abs(lhs.acceptors - rhs.acceptors);
+    const double maxv =
+        static_cast<double>(std::max(lhs.acceptors, rhs.acceptors));
+    score += 1.0 - diff / maxv;
+  } else {
+    score += 1.0;
+  }
+  ++count;
+
+  score += (lhs.amide == rhs.amide) ? 1.0 : 0.0;
+  ++count;
+
+  score += (lhs.aromatic == rhs.aromatic) ? 1.0 : 0.0;
+  ++count;
+
+  const double hydDiff = std::abs(lhs.hydrophobicity - rhs.hydrophobicity);
+  score += 1.0 - hydDiff;
+  ++count;
+
+  return (count > 0) ? score / static_cast<double>(count) : 0.0;
+}
+
+namespace {
+
+double directionalSimilarity(const std::vector<FragmentProfile> &lhs,
+                             const std::vector<FragmentProfile> &rhs) {
+  if (lhs.empty()) {
+    return 0.0;
+  }
+  double sum = 0.0;
+  for (const auto &profile : lhs) {
+    double best = 0.0;
+    for (const auto &candidate : rhs) {
+      const double sim = compareFragmentProfiles(profile, candidate);
+      if (sim > best) {
+        best = sim;
+      }
+    }
+    sum += best;
+  }
+  return sum / static_cast<double>(lhs.size());
+}
+
+}  // namespace
+
+double compareProfileSets(const std::vector<FragmentProfile> &lhs,
+                          const std::vector<FragmentProfile> &rhs) {
+  if (lhs.empty() || rhs.empty()) {
+    return 0.0;
+  }
+  const double forward = directionalSimilarity(lhs, rhs);
+  const double backward = directionalSimilarity(rhs, lhs);
+  return 0.5 * (forward + backward);
+}
+
+double compareMolecules(const ROMol &lhs, const ROMol &rhs) {
+  std::unique_ptr<RWMol> left(new RWMol(lhs));
+  std::unique_ptr<RWMol> right(new RWMol(rhs));
+  MolOps::sanitizeMol(*left);
+  MolOps::sanitizeMol(*right);
+  auto leftProfiles = buildFragmentProfiles(*left);
+  auto rightProfiles = buildFragmentProfiles(*right);
+  return compareProfileSets(leftProfiles, rightProfiles);
+}
+
+}  // namespace FeatTrees
+}  // namespace RDKit
+

--- a/Code/GraphMol/Basement/FeatTrees/FeatTreeSimilarity.h
+++ b/Code/GraphMol/Basement/FeatTrees/FeatTreeSimilarity.h
@@ -1,0 +1,52 @@
+//
+//  Copyright (C) 2024  RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#ifndef RD_FEATTREE_SIMILARITY_H
+#define RD_FEATTREE_SIMILARITY_H
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/Basement/FeatTrees/FeatTree.h>
+
+#include <set>
+#include <vector>
+
+namespace RDKit {
+namespace FeatTrees {
+
+struct FragmentProfile {
+  int volume = 0;
+  bool ring = false;
+  int donors = 0;
+  int acceptors = 0;
+  bool amide = false;
+  bool aromatic = false;
+  double hydrophobicity = 0.0;
+};
+
+FragmentProfile computeFragmentProfile(const ROMol &mol,
+                                       const std::set<unsigned int> &indices);
+
+std::vector<FragmentProfile> buildFragmentProfiles(const ROMol &mol,
+                                                   const FeatTreeGraph &tree);
+
+std::vector<FragmentProfile> buildFragmentProfiles(const ROMol &mol);
+
+double compareFragmentProfiles(const FragmentProfile &lhs,
+                               const FragmentProfile &rhs);
+
+double compareProfileSets(const std::vector<FragmentProfile> &lhs,
+                          const std::vector<FragmentProfile> &rhs);
+
+double compareMolecules(const ROMol &lhs, const ROMol &rhs);
+
+}  // namespace FeatTrees
+}  // namespace RDKit
+
+#endif  // RD_FEATTREE_SIMILARITY_H
+

--- a/Code/GraphMol/Basement/FeatTrees/FeatTreeUtils.cpp
+++ b/Code/GraphMol/Basement/FeatTrees/FeatTreeUtils.cpp
@@ -16,7 +16,7 @@
 #include "FeatTree.h"
 
 #include <boost/graph/biconnected_components.hpp>
-#include <boost/property_map.hpp>
+#include <boost/property_map/property_map.hpp>
 #include <map>
 #include <set>
 

--- a/Code/GraphMol/Basement/FeatTrees/README.md
+++ b/Code/GraphMol/Basement/FeatTrees/README.md
@@ -1,0 +1,69 @@
+# Feature Tree Utilities
+
+This directory collects experimental tooling for constructing and comparing
+feature trees derived from RDKit molecules.  The utilities operate on the
+Boost-based feature-tree graph produced by `FeatTrees::molToBaseTree()` and
+provide both command-line and Python access to fragment-level descriptors and
+similarity scoring.
+
+## Contents
+
+- `FeatTree.h` / `FeatTree.cpp`: definitions of the base feature-tree graph and
+  helpers that cluster fused rings and connector atoms.
+- `FeatTreeUtils.h` / `FeatTreeUtils.cpp`: helper routines used while building
+  the base tree.
+- `FeatTreeSimilarity.h` / `FeatTreeSimilarity.cpp`: fragment profiling and
+  similarity calculation utilities shared by the command-line program and the
+  Python bindings.
+- `ftrees_full.cpp`: a standalone command-line tool that evaluates pairwise
+  feature-tree similarities for SMILES inputs.
+- `testFeatTrees.cpp`: legacy exploratory tests for the feature-tree
+  construction logic.
+
+## Command-line usage
+
+The `ftrees_full` executable expects two or more SMILES strings.  Each SMILES
+is parsed, sanitized, converted into a feature tree, and compared to every other
+input molecule using the fragment-level similarity heuristic.
+
+```bash
+ftrees_full "c1ccccc1O" "CCN(CC)CC"
+```
+
+Each pair of molecules is reported with a similarity score in the range `[0, 1]`.
+
+## Python bindings
+
+The `rdftrees` Python extension exposes the same profiling and scoring logic.
+It can be imported from `rdkit.Chem` once RDKit is built with Python bindings:
+
+```python
+from rdkit import Chem
+from rdkit.Chem import rdftrees
+
+mol1 = Chem.MolFromSmiles("c1ccccc1O")
+mol2 = Chem.MolFromSmiles("CCN(CC)CC")
+
+profiles = rdftrees.build_fragment_profiles(mol1)
+score = rdftrees.compare_molecules(mol1, mol2)
+```
+
+- `build_fragment_profiles(mol, sanitize=True)` returns a list of dictionaries,
+  one per fragment, summarizing the coarse physicochemical properties of the
+  fragment.
+- `compare_molecules(mol1, mol2, sanitize=True)` computes a symmetric
+  similarity score by matching the best fragment pairings between both
+  molecules.
+
+All functions sanitize a working copy of the provided molecules by default.
+Disable sanitization only if the molecules were already processed.
+
+## Implementation notes
+
+The fragment descriptors capture the number of heavy atoms (volume), ring and
+aromatic membership flags, counts of hydrogen-bond donors and acceptors, a
+simple amide-like pattern, and the fraction of carbon atoms as a proxy for
+hydrophobicity.  Similarities are computed by comparing these descriptors with a
+set of heuristic component scores and averaging the best-matching fragment
+pairs between the molecules.
+

--- a/Code/GraphMol/Basement/FeatTrees/ftrees_full.cpp
+++ b/Code/GraphMol/Basement/FeatTrees/ftrees_full.cpp
@@ -1,0 +1,84 @@
+//
+//  Copyright (C) 2024  RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDGeneral/RDLog.h>
+
+#include <GraphMol/GraphMol.h>
+#include <GraphMol/MolOps.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/RWMol.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+
+#include <GraphMol/Basement/FeatTrees/FeatTreeSimilarity.h>
+
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+int main(int argc, char **argv) {
+  if (argc < 3) {
+    std::cerr << "Usage: ftrees_full <smiles1> <smiles2> [<smiles3> ...]" << std::endl;
+    std::cerr << "Computes pairwise feature-tree similarities between the provided SMILES." << std::endl;
+    return 1;
+  }
+
+  RDLog::InitLogs();
+
+  std::vector<std::unique_ptr<RDKit::RWMol>> molecules;
+  molecules.reserve(static_cast<size_t>(argc - 1));
+  std::vector<std::string> inputs;
+  inputs.reserve(static_cast<size_t>(argc - 1));
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string smi = argv[i];
+    std::unique_ptr<RDKit::ROMol> parsed(RDKit::SmilesToMol(smi));
+    if (!parsed) {
+      std::cerr << "Error: failed to parse SMILES '" << smi << "'." << std::endl;
+      return 1;
+    }
+    std::unique_ptr<RDKit::RWMol> mol(new RDKit::RWMol(*parsed));
+    try {
+      RDKit::MolOps::sanitizeMol(*mol);
+    } catch (const RDKit::MolSanitizeException &ex) {
+      std::cerr << "Error: sanitization failed for SMILES '" << smi
+                << "': " << ex.what() << std::endl;
+      return 1;
+    }
+    molecules.push_back(std::move(mol));
+    inputs.push_back(smi);
+  }
+
+  std::vector<std::vector<RDKit::FeatTrees::FragmentProfile>> treeProfiles;
+  treeProfiles.reserve(molecules.size());
+
+  for (const auto &molPtr : molecules) {
+    auto profiles = RDKit::FeatTrees::buildFragmentProfiles(*molPtr);
+    if (profiles.empty()) {
+      std::cerr << "Error: failed to generate feature tree." << std::endl;
+      return 1;
+    }
+    treeProfiles.push_back(std::move(profiles));
+  }
+
+  const size_t count = molecules.size();
+  std::cout << std::fixed << std::setprecision(3);
+  for (size_t i = 0; i < count; ++i) {
+    for (size_t j = i + 1; j < count; ++j) {
+      const double similarity =
+          RDKit::FeatTrees::compareProfileSets(treeProfiles[i], treeProfiles[j]);
+      std::cout << "Similarity(" << inputs[i] << ", " << inputs[j]
+                << ") = " << similarity << std::endl;
+    }
+  }
+
+  return 0;
+}
+

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -8,7 +8,8 @@ rdkit_library(GraphMol
         Renumber.cpp AdjustQuery.cpp Resonance.cpp StereoGroup.cpp
         new_canon.cpp SubstanceGroup.cpp FindStereo.cpp MonomerInfo.cpp
         NontetrahedralStereo.cpp Atropisomers.cpp
-        WedgeBonds.cpp MolProps.cpp 
+        WedgeBonds.cpp MolProps.cpp
+        Basement/FeatTrees/FeatTreeSimilarity.cpp
         SHARED
         LINK_LIBRARIES RDGeometryLib RDGeneral)
 target_compile_definitions(GraphMol PRIVATE RDKIT_GRAPHMOL_BUILD)

--- a/Code/GraphMol/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Wrap/CMakeLists.txt
@@ -24,6 +24,11 @@ rdkit_python_extension(rdqueries
                        LINK_LIBRARIES
                        GraphMol)
 
+rdkit_python_extension(rdftrees
+                       FeatTreeSimilarity.cpp
+                       DEST Chem
+                       LINK_LIBRARIES GraphMol SmilesParse RDGeneral RDBoost)
+
 if(RDK_BUILD_MAEPARSER_SUPPORT)
     set (maesupplier MaeMolSupplier.cpp MaeWriter.cpp)
     include_directories(${maeparser_INCLUDE_DIRS})

--- a/Code/GraphMol/Wrap/FeatTreeSimilarity.cpp
+++ b/Code/GraphMol/Wrap/FeatTreeSimilarity.cpp
@@ -1,0 +1,90 @@
+//
+//  Copyright (C) 2024  RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/python.h>
+
+#include <GraphMol/GraphMol.h>
+#include <GraphMol/MolOps.h>
+#include <GraphMol/RDKitBase.h>
+
+#include <GraphMol/Basement/FeatTrees/FeatTreeSimilarity.h>
+
+#include <memory>
+
+namespace python = boost::python;
+
+namespace {
+
+RDKit::ROMol *copyAndMaybeSanitize(const RDKit::ROMol &mol, bool sanitize) {
+  auto *result = new RDKit::ROMol(mol);
+  if (sanitize) {
+    RDKit::MolOps::sanitizeMol(*result);
+  }
+  return result;
+}
+
+python::dict profileToDict(const RDKit::FeatTrees::FragmentProfile &profile) {
+  python::dict data;
+  data["volume"] = profile.volume;
+  data["ring"] = profile.ring;
+  data["donors"] = profile.donors;
+  data["acceptors"] = profile.acceptors;
+  data["amide"] = profile.amide;
+  data["aromatic"] = profile.aromatic;
+  data["hydrophobicity"] = profile.hydrophobicity;
+  return data;
+}
+
+python::list buildProfiles(const RDKit::ROMol &mol, bool sanitize) {
+  std::unique_ptr<RDKit::ROMol> work(copyAndMaybeSanitize(mol, sanitize));
+  auto profiles = RDKit::FeatTrees::buildFragmentProfiles(*work);
+  python::list result;
+  for (const auto &profile : profiles) {
+    result.append(profileToDict(profile));
+  }
+  return result;
+}
+
+double compareMolecules(const RDKit::ROMol &lhs, const RDKit::ROMol &rhs,
+                        bool sanitize) {
+  std::unique_ptr<RDKit::ROMol> left(copyAndMaybeSanitize(lhs, sanitize));
+  std::unique_ptr<RDKit::ROMol> right(copyAndMaybeSanitize(rhs, sanitize));
+  auto leftProfiles = RDKit::FeatTrees::buildFragmentProfiles(*left);
+  auto rightProfiles = RDKit::FeatTrees::buildFragmentProfiles(*right);
+  return RDKit::FeatTrees::compareProfileSets(leftProfiles, rightProfiles);
+}
+
+}  // namespace
+
+BOOST_PYTHON_MODULE(rdftrees) {
+  python::scope().attr("__doc__") =
+      "Feature-tree utilities for coarse-grained similarity scoring.";
+
+  python::def("build_fragment_profiles", buildProfiles,
+              (python::args("mol"), python::args("sanitize") = true),
+              "Compute fragment-level feature profiles from the molecule's base feature tree.\n\n"
+              "Args:\n"
+              "    mol: An RDKit molecule instance.\n"
+              "    sanitize: If True (default), a sanitized copy of the molecule is used.\n\n"
+              "Returns:\n"
+              "    list[dict]: One dictionary per fragment describing volume, donors,\n"
+              "    acceptors, aromaticity, amide-like character, and hydrophobicity.");
+
+  python::def("compare_molecules", compareMolecules,
+              (python::args("mol1"), python::args("mol2"),
+               python::args("sanitize") = true),
+              "Compute the symmetric feature-tree similarity between two molecules.\n\n"
+              "Args:\n"
+              "    mol1: First RDKit molecule.\n"
+              "    mol2: Second RDKit molecule.\n"
+              "    sanitize: If True (default), sanitized copies of the inputs are used.\n\n"
+              "Returns:\n"
+              "    float: Similarity score in the range [0, 1].");
+}
+


### PR DESCRIPTION
## Summary
- include the correct Boost property_map headers so the feature-tree sources build with Boost 1.83
- use RingInfo to flag ring atoms, sanitize molecules through RWMol, and reuse the sanitized graph when computing fragment profiles
- update the CLI to construct RWMol objects from SMILES input before sanitization so feature-tree profiles can be generated reliably

## Testing
- cmake --build build --target GraphMol
- LD_LIBRARY_PATH=build/lib:$LD_LIBRARY_PATH build/ftrees_full "c1ccccc1O" "CCN(CC)